### PR TITLE
Added missing space after STOP statement

### DIFF
--- a/src/interp_to_ground_track.f90
+++ b/src/interp_to_ground_track.f90
@@ -486,7 +486,7 @@ PROGRAM INTERP_TO_GROUND_TRACK
          id_f1=0 ;  id_v1=0
          !WHERE ( imask == 0 ) xmean = -9999.
          CALL DUMP_2D_FIELD(xmean, 'mean_'//TRIM(cv_mod)//'.nc', cv_mod, xlont, xlatt, 'nav_lon', 'nav_lat', rfill=-9999.)
-         !STOP'lolo'
+         !STOP 'lolo'
       END IF
 
       t_min_e = MINVAL(vt_obs)
@@ -653,7 +653,7 @@ PROGRAM INTERP_TO_GROUND_TRACK
       DEALLOCATE ( show_obs )
    END IF
 
-   IF ( l_debug_mapping ) STOP'l_debug_mapping'
+   IF ( l_debug_mapping ) STOP 'l_debug_mapping'
 
 
 

--- a/src/mod_manip.f90
+++ b/src/mod_manip.f90
@@ -1662,7 +1662,7 @@ CONTAINS
       !PRINT *, 'LOLO EXT_NORTH_TO_90_REGG: YP =', YP(nx/2,:)
       !PRINT *, ''
       !PRINT *, 'LOLO EXT_NORTH_TO_90_REGG: FP =', FP(nx/2,:)
-      !STOP'boo'
+      !STOP 'boo'
 
    END SUBROUTINE EXT_NORTH_TO_90_REGG
 

--- a/src/mod_poly.f90
+++ b/src/mod_poly.f90
@@ -76,7 +76,7 @@ CONTAINS
       rminx = MINVAL(vplon)
       rminy = MINVAL(vplat)
            
-      IF ( (rminx < 0.).OR.(pxpoint < 0.) ) STOP'ERROR (L_InPoly of mod_poly.f90): we only expect positive longitudes!'
+      IF ( (rminx < 0.).OR.(pxpoint < 0.) ) STOP 'ERROR (L_InPoly of mod_poly.f90): we only expect positive longitudes!'
 
       IF ( (rminx < 10.).AND.(rmaxx > 350.) ) THEN
          !! Need to reorganize in frame -180. -- +180.:


### PR DESCRIPTION
The missing spaces after the STOP statements caused a compilation error on gfortran 7.2.0.